### PR TITLE
rework states to support automated testing with kitchen-salt and docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.kitchen
+Gemfile.lock
+*.rpm
+*.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 cache: bundler
 language: ruby
+dist: xenial
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,21 +20,21 @@ services:
 #       Ref: https://github.com/saltstack-formulas/template-formula/issues/121
 env:
   matrix:
-    - INSTANCE: default-debian-10-develop-py3
-    # - INSTANCE: default-ubuntu-1804-develop-py3
+    # - INSTANCE: default-debian-10-develop-py3
+     - INSTANCE: default-ubuntu-1804-develop-py3
     # - INSTANCE: default-centos-7-develop-py3
     # - INSTANCE: default-fedora-30-develop-py3
     # - INSTANCE: default-opensuse-leap-15-develop-py3
     # - INSTANCE: default-amazonlinux-2-develop-py2
-    # - INSTANCE: default-debian-9-2019-2-py3
+     - INSTANCE: default-debian-9-2019-2-py3
     # - INSTANCE: default-ubuntu-1804-2019-2-py3
-     - INSTANCE: default-centos-7-2019-2-py3
+    # - INSTANCE: default-centos-7-2019-2-py3
     # - INSTANCE: default-fedora-30-2019-2-py3
     # - INSTANCE: default-opensuse-leap-15-2019-2-py3
     # - INSTANCE: default-amazonlinux-2-2019-2-py2
     # - INSTANCE: default-debian-9-2018-3-py2
-     - INSTANCE: default-ubuntu-1604-2018-3-py2
-    # - INSTANCE: default-centos-7-2018-3-py2
+    # - INSTANCE: default-ubuntu-1604-2018-3-py2
+     - INSTANCE: default-centos-7-2018-3-py2
     # - INSTANCE: default-fedora-29-2018-3-py2
     # - INSTANCE: default-opensuse-leap-15-2018-3-py2
     # - INSTANCE: default-amazonlinux-2-2018-3-py2
@@ -42,5 +42,5 @@ env:
 before_install:
   - bundle install
 
-script: 
+script:
   - bundle exec kitchen verify ${INSTANCE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 sudo: required
 cache: bundler
 language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+sudo: required
+cache: bundler
+language: ruby
+
+services:
+  - docker
+
+# Make sure the instances listed below match up with
+# the `platforms` defined in `kitchen.yml`
+# NOTE: Please try to select up to six instances that add some meaningful
+#       testing of the formula's behaviour. If possible, try to refrain from
+#       the classical "chosing all the instances because I want to test on
+#       another/all distro/s" trap: it will just add time to the testing (see
+#       the discussion on #121).  As an example, the set chosen below covers
+#       the most used distros families, systemd and non-systemd and the latest
+#       three supported Saltstack versions with python2 and 3.
+#       As for `kitchen.yml`, that should still contain all of the platforms,
+#       to allow for comprehensive local testing
+#       Ref: https://github.com/saltstack-formulas/template-formula/issues/118
+#       Ref: https://github.com/saltstack-formulas/template-formula/issues/121
+env:
+  matrix:
+    - INSTANCE: default-debian-10-develop-py3
+    # - INSTANCE: default-ubuntu-1804-develop-py3
+    # - INSTANCE: default-centos-7-develop-py3
+    # - INSTANCE: default-fedora-30-develop-py3
+    # - INSTANCE: default-opensuse-leap-15-develop-py3
+    # - INSTANCE: default-amazonlinux-2-develop-py2
+    # - INSTANCE: default-debian-9-2019-2-py3
+    # - INSTANCE: default-ubuntu-1804-2019-2-py3
+     - INSTANCE: default-centos-7-2019-2-py3
+    # - INSTANCE: default-fedora-30-2019-2-py3
+    # - INSTANCE: default-opensuse-leap-15-2019-2-py3
+    # - INSTANCE: default-amazonlinux-2-2019-2-py2
+    # - INSTANCE: default-debian-9-2018-3-py2
+     - INSTANCE: default-ubuntu-1604-2018-3-py2
+    # - INSTANCE: default-centos-7-2018-3-py2
+    # - INSTANCE: default-fedora-29-2018-3-py2
+    # - INSTANCE: default-opensuse-leap-15-2018-3-py2
+    # - INSTANCE: default-amazonlinux-2-2018-3-py2
+
+before_install:
+  - bundle install
+
+script: 
+  - bundle exec kitchen verify ${INSTANCE}

--- a/FORMULA
+++ b/FORMULA
@@ -1,0 +1,9 @@
+name: template
+os: Debian, Ubuntu, RedHat, CentOS
+os_family: Debian, RedHat
+version: 2.6.0 
+release: 1
+minimum_version: 2018.3
+summary: bro formula
+description: Formula to install BRO network security monitor(NSM)
+top_level_dir: bro

--- a/FORMULA
+++ b/FORMULA
@@ -1,7 +1,7 @@
-name: template
+name: bro
 os: Debian, Ubuntu, RedHat, CentOS
 os_family: Debian, RedHat
-version: 2.6.0 
+version: 2.6.0
 release: 1
 minimum_version: 2018.3
 summary: bro formula

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem 'kitchen-docker', '>= 2.9'
+gem 'kitchen-salt', '>= 0.6.0'
+gem 'kitchen-inspec', '>= 1.1'
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2016 Brandon Keep bkeep<AT>alias454studios<DOT>com
+   Copyright (c) 2019 Brandon Keep bkeep<AT>alias454studios<DOT>com
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -1,65 +1,133 @@
-================
+===========
 bro-formula
-================
+===========
+
+|img_travis|
+
+.. |img_travis| image:: https://travis-ci.com/saltstack-formulas/bro-formula.svg?branch=master
+      :alt: Travis CI Build Status
+   :scale: 100%
 
 A saltstack formula to install BRO/Zeek Network Security Monitor on RHEL or Debian based systems.
 
 Supports one capture interface at the moment. Adding ability to control multiple capture interfaces is on the TODO list
 
+.. contents:: **Table of Contents**
+      :depth: 1
+
 Optional
-================
+========
 
 Formulas exist to help with installation and management of
 other components such as pf_ring.
 
-pfring-formula
+pfring-formula  
 https://github.com/saltstack-formulas/pfring-formula
 
+Compile your own bro/zeek package using the guide `RPM package creation for BRO IDS Deployments https://alias454.com/rpm-package-creation-for-bro-ids-deployments/`_.
 
-Available states
-================
+General notes
+=============
 
 .. note::
+
+    The ``FORMULA`` file, contains informtion about the version of this formula, tested OS and OS families, and the minimum tested version of salt.
 
     See the full `Salt Formulas installation and usage instructions
     <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
+Available states
+================
+
 .. contents::
     :local:
 
-``bro-repo``
-------------
-Manage repo files on RHEL/CentOS 7/Debian systems
+``bro``
+-------
+*Meta-state (This is a state that includes other states)*.
 
-``bro-prereqs``
-------------
-Install prerequisite packages
+Installs **bro** and it's requirements, manages the configuration file, and starts the service.
 
-``bro-package``
-------------
-Install bro packages
+``bro.bro-repo``
+----------------
+Manage repo files on RHEL/CentOS 7/Debian systems.
 
-``bro-config``
-------------
-Manage configuration file placement
+``bro.bro-prereqs``
+-------------------
+Install prerequisite packages.
 
-``bro-bpfconf``
-------------
-Manage BPF module and configuration
-Supports a single bro-bpf.conf file that applies to all capture interfaces
+``bro.bro-package``
+-------------------
+Install bro packages.
 
-``bro-sendmail``
-------------
-If using sendmail(postfix), manage relay host and service
+``bro.bro-config``
+------------------
+Manage configuration file placement.
 
-``bro-service``
-------------
-Manage bro service and a service to manage promiscuous mode of defined network interfaces on RHEL/CentOS 7/Debian systems
+``bro.bro-bpfconf``
+-------------------
+Manage BPF module and configuration.  
+Supports a single bro-bpf.conf file that applies to all capture interfaces.
 
-``bro-bropkg``
-------------
+``bro.bro-sendmail``
+--------------------
+If using sendmail(postfix), manage relay host and service.
+
+``bro.bro-service``
+-------------------
+Manage bro service and a service to manage promiscuous mode of defined network interfaces on RHEL/CentOS 7/Debian systems.
+
+``bro.bro-syslog``
+-------------------
+Manage rsyslog config and service to send specifc log types to a remote collector.
+
+``bro.bro-bropkg``
+------------------
 Manage bro-pkg pip module and plugin installations.
 
-``bro-cron``
+``bro.bro-cron``
+----------------
+Manage broctl cron entry.
+
+Testing
+=======
+
+Linux testing is done with ``kitchen-salt``.
+
+Requirements
 ------------
-Manage broctl cron entry
+
+* Ruby
+* Docker
+
+.. code-block:: bash
+
+   $ gem install bundler
+   $ bundle install
+   $ bin/kitchen test [platform]
+
+Where ``[platform]`` is the platform name defined in ``kitchen.yml``,
+e.g. ``debian-9-2019-2-py3``.
+
+Test options
+-------------
+
+``bin/kitchen converge``
+************************
+Creates the docker instance and runs the ``bro`` main state, ready for testing.
+
+``bin/kitchen verify``
+**********************
+Runs the ``inspec`` tests on the actual instance.
+
+``bin/kitchen destroy``
+***********************
+Removes the docker instance.
+
+``bin/kitchen test``
+********************
+Runs all of the stages above in one go: i.e. ``destroy`` + ``converge`` + ``verify`` + ``destroy``.
+
+``bin/kitchen login``
+*********************
+Gives you SSH access to the instance for manual testing if automated testing fails.

--- a/README.rst
+++ b/README.rst
@@ -1,22 +1,21 @@
-===========
 bro-formula
 ===========
 
 |img_travis|
 
 .. |img_travis| image:: https://travis-ci.com/saltstack-formulas/bro-formula.svg?branch=master
-      :alt: Travis CI Build Status
+   :alt: Travis CI Build Status
    :scale: 100%
 
 A saltstack formula to install BRO/Zeek Network Security Monitor on RHEL or Debian based systems.
 
 Supports one capture interface at the moment. Adding ability to control multiple capture interfaces is on the TODO list
 
-.. contents:: **Table of Contents**
+.. contents:: ^^Table of Contents^^
       :depth: 1
 
 Optional
-========
+--------
 
 Formulas exist to help with installation and management of
 other components such as pf_ring.
@@ -27,7 +26,7 @@ https://github.com/saltstack-formulas/pfring-formula
 Compile your own bro/zeek package using the guide `RPM package creation for BRO IDS Deployments https://alias454.com/rpm-package-creation-for-bro-ids-deployments/`_.
 
 General notes
-=============
+-------------
 
 .. note::
 
@@ -37,65 +36,65 @@ General notes
     <http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html>`_.
 
 Available states
-================
+----------------
 
 .. contents::
     :local:
 
 ``bro``
--------
-*Meta-state (This is a state that includes other states)*.
+^^^^^^^
+^Meta-state (This is a state that includes other states)^.
 
-Installs **bro** and it's requirements, manages the configuration file, and starts the service.
+Installs ^^bro^^ and it's requirements, manages the configuration file, and starts the service.
 
 ``bro.bro-repo``
-----------------
+^^^^^^^^^^^^^^^^
 Manage repo files on RHEL/CentOS 7/Debian systems.
 
 ``bro.bro-prereqs``
--------------------
+^^^^^^^^^^^^^^^^^^^
 Install prerequisite packages.
 
 ``bro.bro-package``
--------------------
+^^^^^^^^^^^^^^^^^^^
 Install bro packages.
 
 ``bro.bro-config``
-------------------
+^^^^^^^^^^^^^^^^^^
 Manage configuration file placement.
 
 ``bro.bro-bpfconf``
--------------------
+^^^^^^^^^^^^^^^^^^^
 Manage BPF module and configuration.  
 Supports a single bro-bpf.conf file that applies to all capture interfaces.
 
 ``bro.bro-sendmail``
---------------------
+^^^^^^^^^^^^^^^^^^^^
 If using sendmail(postfix), manage relay host and service.
 
 ``bro.bro-service``
--------------------
+^^^^^^^^^^^^^^^^^^^
 Manage bro service and a service to manage promiscuous mode of defined network interfaces on RHEL/CentOS 7/Debian systems.
 
 ``bro.bro-syslog``
--------------------
+^^^^^^^^^^^^^^^^^^^
 Manage rsyslog config and service to send specifc log types to a remote collector.
 
 ``bro.bro-bropkg``
-------------------
+^^^^^^^^^^^^^^^^^^
 Manage bro-pkg pip module and plugin installations.
 
 ``bro.bro-cron``
-----------------
+^^^^^^^^^^^^^^^^
 Manage broctl cron entry.
 
 Testing
-=======
+-------
 
 Linux testing is done with ``kitchen-salt``.
 
 Requirements
-------------
+^^^^^^^^^^^^
 
 * Ruby
 * Docker
@@ -110,24 +109,24 @@ Where ``[platform]`` is the platform name defined in ``kitchen.yml``,
 e.g. ``debian-9-2019-2-py3``.
 
 Test options
--------------
+^^^^^^^^^^^^^
 
 ``bin/kitchen converge``
-************************
+^^^^^^^^^^^^^^^^^^^^^^^^
 Creates the docker instance and runs the ``bro`` main state, ready for testing.
 
 ``bin/kitchen verify``
-**********************
+^^^^^^^^^^^^^^^^^^^^^^
 Runs the ``inspec`` tests on the actual instance.
 
 ``bin/kitchen destroy``
-***********************
+^^^^^^^^^^^^^^^^^^^^^^^
 Removes the docker instance.
 
 ``bin/kitchen test``
-********************
+^^^^^^^^^^^^^^^^^^^^
 Runs all of the stages above in one go: i.e. ``destroy`` + ``converge`` + ``verify`` + ``destroy``.
 
 ``bin/kitchen login``
-*********************
+^^^^^^^^^^^^^^^^^^^^^
 Gives you SSH access to the instance for manual testing if automated testing fails.

--- a/bro/bro-bpfconf.sls
+++ b/bro/bro-bpfconf.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 {% from "bro/map.jinja" import host_lookup as config with context %}
 {% if config.bro.bpf.use_BPFconf == 'True' %}
 

--- a/bro/bro-bropkg.sls
+++ b/bro/bro-bropkg.sls
@@ -81,7 +81,7 @@ pip-package-install-bro-pkg:
 bro-pkg-autoconfig:
   cmd.run:
     - name: bro-pkg autoconfig
-    - creates: /root/.bro-pkg/config # either .zkg or .bro-pkg
+    - creates: /root/.zkg/config # either .zkg or .bro-pkg
     - unless: echo $(which bro-pkg) |grep "no bro-pkg"
     - runas: root
     - require:

--- a/bro/bro-bropkg.sls
+++ b/bro/bro-bropkg.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 {% from "bro/map.jinja" import host_lookup as config with context %}
 {% if config.bro.use_BroPKG == 'True' %}
 # bro-pkg is not bundled with the main install so we install it.

--- a/bro/bro-config.sls
+++ b/bro/bro-config.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 {% from "bro/map.jinja" import host_lookup as config with context %}
 
 # Update the current path with bro path

--- a/bro/bro-config.sls
+++ b/bro/bro-config.sls
@@ -62,6 +62,7 @@ group-manage-bro:
       - service: service-bro
         
 # Configure network options
+{% if config.bro.interfaces.capture.enable == 'True' %}
 network_configure_{{ config.bro.interfaces.capture.device_names }}:
   network.managed:
     - name: {{ config.bro.interfaces.capture.device_names }}
@@ -79,6 +80,7 @@ network_configure_{{ config.bro.interfaces.capture.device_names }}:
     - gso: off
     - gro: off
     - lro: off
+{% endif %}
 
 # Manage systemd unit file to control promiscuous mode
 /usr/lib/systemd/system/netcfg@.service:
@@ -116,8 +118,8 @@ network_configure_{{ config.bro.interfaces.capture.device_names }}:
 
         [Service]
         ExecStartPre=-{{ config.bro.BinDir }}/broctl cleanup
-        ExecStartPre={{ config.bro.BinDir }}/broctl check
-        ExecStartPre={{ config.bro.BinDir }}/broctl install
+        #ExecStartPre={{ config.bro.BinDir }}/broctl check
+        #ExecStartPre={{ config.bro.BinDir }}/broctl install
         ExecStartPre={{ config.bro.BinDir }}/broctl deploy
         ExecStart={{ config.bro.BinDir }}/broctl start
         ExecStop={{ config.bro.BinDir }}/broctl stop

--- a/bro/bro-cron.sls
+++ b/bro/bro-cron.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 {% from "bro/map.jinja" import host_lookup as config with context %}
 
 # Make sure cronie is installed

--- a/bro/bro-cron.sls
+++ b/bro/bro-cron.sls
@@ -1,5 +1,15 @@
 {% from "bro/map.jinja" import host_lookup as config with context %}
 
+# Make sure cronie is installed
+{% if salt.grains.get('os_family') == 'RedHat' %}
+package-install-cronie-bro:
+  pkg.installed:
+    - pkgs:
+      - cronie
+    - refresh: True
+{% elif salt.grains.get('os_family') == 'Debian' %}
+{% endif %}
+
 # Setup Cron for BRO runs every 5 minutes
 {{ config.bro.BinDir }}/broctl cron:
   cron.present:

--- a/bro/bro-package.sls
+++ b/bro/bro-package.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 {% from "bro/map.jinja" import host_lookup as config with context %}
 {% if config.package.install_type == 'package' %}
 

--- a/bro/bro-package.sls
+++ b/bro/bro-package.sls
@@ -23,6 +23,7 @@ package-install-bro:
   file.managed:
     - source: {{ package.source_url }}/{{ package.package }}.{{ package.type }}
     - source_hash: {{ package.hash }}
+    - reload_modules: true
     - user: root
     - group: root
     - mode: '0644'

--- a/bro/bro-package.sls
+++ b/bro/bro-package.sls
@@ -16,29 +16,13 @@ package-install-bro:
       - service: service-bro
 
 {% elif config.package.install_type == 'local' %}
-# Get package file from remote source and store it in salt://bro/files/
-{% if config.package.use_remote_pkg == 'True' %}
-{% for package in config.package.local_package %}
-{{ package.files_path }}/{{ package.package }}.{{ package.type }}:
-  file.managed:
-    - source: {{ package.source_url }}/{{ package.package }}.{{ package.type }}
-    - source_hash: {{ package.hash }}
-    - reload_modules: true
-    - user: root
-    - group: root
-    - mode: '0644'
-    - onlyif: ls {{ package.files_path }}/{{ package.package }}.{{ package.type }} |grep 'No such file'
-    - require_in:
-      - pkg: package-install-bro
-{% endfor %}
-{% endif %}
 
 # Install bro from a local package
 package-install-bro:
   pkg.installed:
     - sources:
     {% for package in config.package.local_package %}
-      - {{ package.name }}: salt://bro/files/{{ package.package }}.{{ package.type }}
+      - {{ package.name }}: {{ package.source }}/{{ package.package }}.{{ package.type }}
     {% endfor %}
     - refresh: True
     - skip_verify: {{ config.package.skip_verify }}

--- a/bro/bro-package.sls
+++ b/bro/bro-package.sls
@@ -16,6 +16,21 @@ package-install-bro:
       - service: service-bro
 
 {% elif config.package.install_type == 'local' %}
+# Get package file from remote source and store it in salt://bro/files/
+{% if config.package.use_remote_pkg == 'True' %}
+{% for package in config.package.local_package %}
+{{ package.files_path }}/{{ package.package }}.{{ package.type }}:
+  file.managed:
+    - source: {{ package.source_url }}/{{ package.package }}.{{ package.type }}
+    - source_hash: {{ package.hash }}
+    - user: root
+    - group: root
+    - mode: '0644'
+    - onlyif: ls {{ package.files_path }}/{{ package.package }}.{{ package.type }} |grep 'No such file'
+    - require_in:
+      - pkg: package-install-bro
+{% endfor %}
+{% endif %}
 
 # Install bro from a local package
 package-install-bro:

--- a/bro/bro-prereqs.sls
+++ b/bro/bro-prereqs.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 {% from "bro/map.jinja" import host_lookup as config with context %}
 
 # Install epel for RHEL based systems

--- a/bro/bro-repo.sls
+++ b/bro/bro-repo.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 {% from "bro/map.jinja" import host_lookup as config with context %}
 {% if config.package.install_type == 'package' %}
 # Installing from package

--- a/bro/bro-sendmail.sls
+++ b/bro/bro-sendmail.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 {% from "bro/map.jinja" import host_lookup as config with context %}
 {% if config.bro.optional.use_sendmail == 'True' %}
 

--- a/bro/bro-service.sls
+++ b/bro/bro-service.sls
@@ -1,6 +1,13 @@
 {% from "bro/map.jinja" import host_lookup as config with context %}
 
-# Make sure bro service is running and restart the service unless
+# Prior to enabling the service reload systemctl
+systemd-reload-bro:
+  cmd.run:
+    - name: systemctl --system daemon-reload
+    - onchanges:
+      - file: /usr/lib/systemd/system/bro.service
+
+# Make sure bro service is running and restart the service
 service-bro:
   service.running:
     - name: bro
@@ -10,9 +17,14 @@ service-bro:
       - file: {{ config.bro.CfgDir }}/node.cfg
       - file: {{ config.bro.CfgDir }}/networks.cfg
       - file: /usr/lib/systemd/system/bro.service
+    {% if config.bro.interfaces.capture.enable == 'True' %}
       - network: network_configure_{{ config.bro.interfaces.capture.device_names }}
+    {% endif %}
+    - require:
+      - cmd: systemd-reload-bro
 
 # Make sure netcfg@ service is running and enabled
+{% if config.bro.interfaces.capture.enable == 'True' %}
 service-netcfg@{{ config.bro.interfaces.capture.device_names }}:
   service.running:
     - name: netcfg@{{ config.bro.interfaces.capture.device_names }}
@@ -20,3 +32,4 @@ service-netcfg@{{ config.bro.interfaces.capture.device_names }}:
     - require:
       - file: /usr/lib/systemd/system/netcfg@.service
       - network: network_configure_{{ config.bro.interfaces.capture.device_names }}
+{% endif %}

--- a/bro/bro-service.sls
+++ b/bro/bro-service.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 {% from "bro/map.jinja" import host_lookup as config with context %}
 
 # Prior to enabling the service reload systemctl

--- a/bro/bro-syslog.sls
+++ b/bro/bro-syslog.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 {% from "bro/map.jinja" import host_lookup as config with context %}
 {% if config.bro.logging.use_rsyslog == 'True' %}
 

--- a/bro/bro-syslog.sls
+++ b/bro/bro-syslog.sls
@@ -1,0 +1,32 @@
+{% from "bro/map.jinja" import host_lookup as config with context %}
+{% if config.bro.logging.use_rsyslog == 'True' %}
+
+# Configure rsyslog settings for sending bro logs to a remote log collector
+bro_rsyslog_config:
+  file.managed:
+    - name: /etc/rsyslog.d/00-bro.conf
+    - source: salt://bro/files/rsyslog_00-bro.conf
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: '0644'
+
+{% if salt.grains.get('os_family') == 'RedHat' %}
+command-semanage-{{ config.bro.logging.protocol }}-{{ config.bro.logging.port }}-rsyslog-port:
+  cmd.run:
+    - name: semanage port -a -t syslogd_port_t -p {{ config.bro.logging.protocol }} {{ config.bro.logging.port }} 
+    - unless: semanage port -l |grep syslog |grep {{ config.bro.logging.port }}
+    - require-in:
+      - service: service-rsyslog-bro
+    - require:
+      - pkg: package-install-bro
+{% endif %}
+
+# Make sure rsyslog is running if use_rsyslog is true
+service-rsyslog-bro:
+  service.running:
+    - name: rsyslog
+    - enable: True
+    - watch:
+      - file: bro_rsyslog_config
+{% endif %}

--- a/bro/files/rsyslog_00-bro.conf
+++ b/bro/files/rsyslog_00-bro.conf
@@ -1,0 +1,320 @@
+{% from "bro/map.jinja" import host_lookup as config with context -%}
+#### BRO IDS configuration file ####
+# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+# If selinux is enabled run semanage port -a -t syslogd_port_t -p tcp {{ config.bro.logging.port }}
+
+#### MODULES ####
+module(load="imfile")
+
+#### Templates ####
+template (name="BRO_Logs" type="string"
+          string="<%PRI%>%PROTOCOL-VERSION% %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% %PROCID% %MSGID% %STRUCTURED-DATA% %$!msg%\n"
+         )
+
+#### RULES for where to send Log Files ####
+# Send messages over TCP using the BRO_Logs template
+ruleset(name="sendBROLogs") {
+    if $msg startswith not "#" then {
+        set $!msg = replace($msg, "|", "%7C"); # Handle existing pipe char
+        set $!msg = replace($!msg, "\t", "|");
+
+        action (
+            type="omfwd"
+            protocol="{{ config.bro.logging.protocol }}"
+            target="{{ config.bro.logging.target }}"
+            port="{{ config.bro.logging.port }}"
+            template="BRO_Logs"
+        )
+    }
+}
+
+#### Inputs ####
+# Comment out sections to not send specifc logs
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/notice.log"
+    Tag="bro_notice"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/weird.log"
+    Tag="bro_weird"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/conn.log"
+    Tag="bro_conn"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/dns.log"
+    Tag="bro_dns"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/dhcp.log"
+    Tag="bro_dhcp"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/http.log"
+    Tag="bro_http"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/software.log"
+    Tag="bro_software"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/tunnel.log"
+    Tag="bro_tunnel"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/smtp.log"
+    Tag="bro_smtp"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/broker.log"
+    Tag="bro_broker"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/capture_loss.log"
+    Tag="bro_capture_loss"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/cluster.log"
+    Tag="bro_cluster"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/dce_rpc.log"
+    Tag="bro_dce_rpc"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/files.log"
+    Tag="bro_files"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/ftp.log"
+    Tag="bro_ftp"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/irc.log"
+    Tag="bro_irc"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/kerberos.log"
+    Tag="bro_kerberos"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/mysql.log"
+    Tag="bro_mysql"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/ntlm.log"
+    Tag="bro_ntlm"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/packet_filter.log"
+    Tag="bro_packet_filter"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/pe.log"
+    Tag="bro_pe"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/radius.log"
+    Tag="bro_radius"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/reporter.log"
+    Tag="bro_reporter"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/rdp.log"
+    Tag="bro_rdp"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/sip.log"
+    Tag="bro_sip"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/smb_files.log"
+    Tag="bro_smb_files"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/smb_mapping.log"
+    Tag="bro_smb_mapping"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/snmp.log"
+    Tag="bro_snmp"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/ssh.log"
+    Tag="bro_ssh"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/ssl.log"
+    Tag="bro_ssl"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/stats.log"
+    Tag="bro_stats"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+
+input (
+    type="imfile"
+    File="/opt/bro/logs/current/x509.log"
+    Tag="bro_x509"
+    Facility="local7"
+    Severity="info"
+    RuleSet="sendBROLogs"
+)
+

--- a/bro/init.sls
+++ b/bro/init.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
 include:
   - .bro-repo
   - .bro-prereqs

--- a/bro/init.sls
+++ b/bro/init.sls
@@ -4,7 +4,7 @@ include:
   - .bro-package
   - .bro-config
   - .bro-bpfconf
-  - .bro-sendmail  
+  - .bro-sendmail
   - .bro-service
   - .bro-syslog
   - .bro-bropkg

--- a/bro/init.sls
+++ b/bro/init.sls
@@ -6,5 +6,6 @@ include:
   - .bro-bpfconf
   - .bro-sendmail  
   - .bro-service
+  - .bro-syslog
   - .bro-bropkg
   - .bro-cron

--- a/bro/map.jinja
+++ b/bro/map.jinja
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=jinja
+
 # Default setting for base_dir
 {% set base_dir = salt['pillar.get']('bro:lookup:bro:base_dir', '/opt/bro') %}
 

--- a/bro/map.jinja
+++ b/bro/map.jinja
@@ -35,7 +35,7 @@
       'lb_procs': '1',
       'logging':
       {
-        'use_rsyslog': 'True',
+        'use_rsyslog': 'False',
         'target': 'esnode00.alias454.local',
         'port': '13514',
         'protocol': 'tcp',

--- a/bro/map.jinja
+++ b/bro/map.jinja
@@ -57,6 +57,7 @@
         'management': 'eth0',
         'capture':
         {
+          'enable': 'False',
           'device_names': 'eth1',
           'enable_tx': '0',
           'min_num_slots': '4096',
@@ -73,6 +74,7 @@
         'management': 'eth0',
         'capture':
         {
+          'enable': 'True',
           'device_names': 'eth1',
           'enable_tx': '0',
           'min_num_slots': '32768',

--- a/bro/map.jinja
+++ b/bro/map.jinja
@@ -33,6 +33,13 @@
       'use_afpacket': 'False',
       'lb_method': 'pf_ring',
       'lb_procs': '1',
+      'logging':
+      {
+        'use_rsyslog': 'True',
+        'target': 'esnode00.alias454.local',
+        'port': '13514',
+        'protocol': 'tcp',
+      },
       'bpf':
       {
         'use_BPFconf': 'True',
@@ -48,7 +55,7 @@
       {
         'ip_binary_path': '/sbin/ip',
         'management': 'eth0',
-        'capture': 
+        'capture':
         {
           'device_names': 'eth1',
           'enable_tx': '0',
@@ -64,7 +71,7 @@
       'interfaces':
       {
         'management': 'eth0',
-        'capture': 
+        'capture':
         {
           'device_names': 'eth1',
           'enable_tx': '0',
@@ -100,7 +107,7 @@
     }
   }
 } %}
-{% set os_map = os_lookup.get(grains.os_family, {}) %} 
+{% set os_map = os_lookup.get(grains.os_family, {}) %}
 
 # update the default config with os specific settings
 {% do default_config.update(os_map) %}

--- a/bro/map.jinja
+++ b/bro/map.jinja
@@ -91,6 +91,7 @@
     'package':
     {
       'install_type': 'package',
+      'use_remote_pkg': 'False',
       'use_repo': 'False',
       'skip_verify': '0',
       'repo_baseurl': 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/',
@@ -102,6 +103,7 @@
     'package':
     {
       'install_type': 'package',
+      'use_remote_pkg': 'False',
       'use_repo': 'False',
       'skip_verify': '0',
       'repo_baseurl': 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/',

--- a/bro/map.jinja
+++ b/bro/map.jinja
@@ -91,7 +91,6 @@
     'package':
     {
       'install_type': 'package',
-      'use_remote_pkg': 'False',
       'use_repo': 'False',
       'skip_verify': '0',
       'repo_baseurl': 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/',
@@ -103,7 +102,6 @@
     'package':
     {
       'install_type': 'package',
-      'use_remote_pkg': 'False',
       'use_repo': 'False',
       'skip_verify': '0',
       'repo_baseurl': 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/',

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# For help on this file's format, see https://kitchen.ci/
+driver:
+  name: docker
+  use_sudo: false
+  privileged: true
+  run_command: /lib/systemd/systemd
+
+platforms:
+  ## SALT `develop`
+  - name: debian-10-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:debian-10
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  - name: ubuntu-1804-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:ubuntu-18.04
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  - name: centos-7-develop-py3
+    driver:
+      image: netmanagers/salt-develop-py3:centos-7
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  #- name: fedora-30-develop-py3
+  #  driver:
+  #    image: netmanagers/salt-develop-py3:fedora-30
+  #    provision_command:
+  #      - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+  #      - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  #- name: opensuse-leap-15-develop-py3
+  #  driver:
+  #    image: netmanagers/salt-develop-py3:opensuse-leap-15
+  #    provision_command:
+  #      - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+  #      - sh bootstrap-salt.sh -XdPbfrq -x python3 git develop
+  #    run_command: /usr/lib/systemd/systemd
+  - name: amazonlinux-2-develop-py2
+    driver:
+      image: netmanagers/salt-develop-py2:amazonlinux-2
+      provision_command:
+        - curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
+        - sh bootstrap-salt.sh -XdPbfrq -x python2 git develop
+
+  ## SALT `2019.2`
+  - name: debian-9-2019-2-py3
+    driver:
+      image: netmanagers/salt-2019.2-py3:debian-9
+  - name: ubuntu-1804-2019-2-py3
+    driver:
+      image: netmanagers/salt-2019.2-py3:ubuntu-18.04
+  - name: centos-7-2019-2-py3
+    driver:
+      image: netmanagers/salt-2019.2-py3:centos-7
+  #- name: fedora-30-2019-2-py3
+  #  driver:
+  #    image: netmanagers/salt-2019.2-py3:fedora-30
+  #- name: opensuse-leap-15-2019-2-py3
+  #  driver:
+  #    image: netmanagers/salt-2019.2-py3:opensuse-leap-15
+  #    run_command: /usr/lib/systemd/systemd
+  - name: amazonlinux-2-2019-2-py2
+    driver:
+      image: netmanagers/salt-2019.2-py2:amazonlinux-2
+
+  ## SALT `2018.3`
+  - name: debian-9-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:debian-9
+  - name: ubuntu-1604-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:ubuntu-16.04
+  - name: centos-7-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:centos-7
+  #- name: fedora-29-2018-3-py2
+  #  driver:
+  #    image: netmanagers/salt-2018.3-py2:fedora-29
+  #- name: opensuse-leap-15-2018-3-py2
+  #  driver:
+  #    image: netmanagers/salt-2018.3-py2:opensuse-leap-15
+  #    run_command: /usr/lib/systemd/systemd
+  - name: amazonlinux-2-2018-3-py2
+    driver:
+      image: netmanagers/salt-2018.3-py2:amazonlinux-2
+
+provisioner:
+  name: salt_solo
+  log_level: info
+  salt_install: none
+  require_chef: false
+  formula: bro
+  salt_copy_filter:
+    - .kitchen
+    - .git
+
+verifier:
+  # https://www.inspec.io/
+  name: inspec
+  sudo: true
+  # cli, documentation, html, progress, json, json-min, json-rspec, junit
+  reporter:
+    - cli
+
+suites:
+  - name: default
+    provisioner:
+      state_top:
+        base:
+          '*':
+            - bro
+      pillars:
+        top.sls:
+          base:
+            '*':
+              - bro
+      pillars_from_files:
+        bro.sls: test/salt/pillar/default.sls
+    verifier:
+      inspec_tests:
+        - path: test/integration/default

--- a/pillar.example
+++ b/pillar.example
@@ -57,6 +57,8 @@ bro:
       use_afpacket: 'True'                   # If you use AF_PACKET set this to True. Must use "custom" lb_method and use_BroPKG set to True
       lb_method: 'custom'                    # Load balancer type ("pf_ring" or "custom" are supported)
       lb_procs: '2'                          # Number of processors to run BRO workers with
+      logging:
+        use_rsyslog: 'True'                  # Enable rsyslog usage
       bpf:
         use_BPFconf: 'True'                  # Use Berkeley Packet Filter(BPF) on capture interfaces
         bpf_rules: []                        # Add custom BPF rules

--- a/pillar.example
+++ b/pillar.example
@@ -9,17 +9,13 @@ bro:
           package: 'Bro-2.6-195-Linux-x86_64'       # Custom package to be deployed
           name: 'bro'                               # Name of installed package
           type: 'rpm'                               # Type should be deb or rpm based on platform
-          files_path: '/srv/salt/bro/files'         # Local file path for package storage
-          source_url: 'https://git.io/fj7g3'        # Short link to alias454 gists where test package lives
-          hash: 'a3ab22252d25a1b8cc50ca0e681cacee9bbd93472dd51ae741eafa23016d21cf'
-      use_remote_pkg: 'False'                       # Get local_package file from a remote source
+          source: 'salt://bro/files'                # URI Path can be salt, ftp, https, or file path to package (no trailing /)
       use_repo: 'False'                             # Bro can be installed from epel or a local rpm not just bro repos
       repo_baseurl: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/repodata/repomd.xml.key'
       skip_verify: '0'
     {% elif grains['os_family'] == 'Debian' %}
       install_type: 'package'                       # Install type can be package (support for tarball or local not implemented)
-      use_remote_pkg: 'False'                       # Get local_package file from a remote source
       use_repo: 'False'                             # Debian 9 does not require an external repo
       repo_baseurl: 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:bro/Debian_8.0/Release.key'

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # BRO docs https://www.bro.org/documentation/index.html
 bro:
   lookup:

--- a/pillar.example
+++ b/pillar.example
@@ -9,12 +9,17 @@ bro:
           package: 'Bro-2.6-195-Linux-x86_64'       # Custom package to be deployed
           name: 'bro'                               # Name of installed package
           type: 'rpm'                               # Type should be deb or rpm based on platform
+          files_path: '/srv/salt/bro/files'         # Local file path for package storage
+          source_url: 'https://git.io/fj7g3'        # Short link to alias454 gists where test package lives
+          hash: 'a3ab22252d25a1b8cc50ca0e681cacee9bbd93472dd51ae741eafa23016d21cf'
+      use_remote_pkg: 'False'                       # Get local_package file from a remote source
       use_repo: 'False'                             # Bro can be installed from epel or a local rpm not just bro repos
       repo_baseurl: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/repodata/repomd.xml.key'
       skip_verify: '0'
     {% elif grains['os_family'] == 'Debian' %}
       install_type: 'package'                       # Install type can be package (support for tarball or local not implemented)
+      use_remote_pkg: 'False'                       # Get local_package file from a remote source
       use_repo: 'False'                             # Debian 9 does not require an external repo
       repo_baseurl: 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:bro/Debian_8.0/Release.key'

--- a/pillar.example
+++ b/pillar.example
@@ -3,7 +3,7 @@ bro:
   lookup:
     package:
     {% if grains['os_family'] == 'RedHat' %}
-      install_type: 'local'                         # Install type can be package or local (support for tarball not implemented) 
+      install_type: 'local'                         # Install type can be package or local (support for tarball not implemented)
       local_package:                                # Can be multiple packages like bro, broctl, broccoli etc.
         - pack_id: 'bro-full'
           package: 'Bro-2.6-195-Linux-x86_64'       # Custom package to be deployed
@@ -14,7 +14,7 @@ bro:
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/repodata/repomd.xml.key'
       skip_verify: '0'
     {% elif grains['os_family'] == 'Debian' %}
-      install_type: 'package'                       # Install type can be package (support for tarball or local not implemented) 
+      install_type: 'package'                       # Install type can be package (support for tarball or local not implemented)
       use_repo: 'False'                             # Debian 9 does not require an external repo
       repo_baseurl: 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:bro/Debian_8.0/Release.key'
@@ -22,9 +22,13 @@ bro:
     {% endif %}
     bro:
       use_BroPKG: 'True'                     # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
+    {% if grains['os_family'] == 'RedHat' %}
       python_pip_pkg: 'python36-pip'         # Can be pip or pip3 but only gets installed if use_BroPKG == True
+    {% elif grains['os_family'] == 'Debian' %}
+      python_pip_pkg: 'python3-pip'         # Can be pip or pip3 but only gets installed if use_BroPKG == True
+    {% endif %}
       python_pip_cmd: 'pip3'                 # Otherwise, the pip install is skipped and bro-pkg is not configured
-      addon_plugins:                         # List of plugins to install if bro-pkg is enabled 
+      addon_plugins:                         # List of plugins to install if bro-pkg is enabled
         - plugin: 'bro-af_packet-plugin'     # af_packet is required when use_afpacket == True
       MailTo: 'root@localhost'               # Recipient address for all emails sent out by Bro and BroControl
       SendMail: '/sbin/sendmail'             # Path to sendmail binary
@@ -48,7 +52,7 @@ bro:
       CfgDir: '/etc/bro'                     # Default config directory location for Debian
       ShareDir: '/usr/share/bro'             # Location of shared resources (site local)
     {% endif %}
-      mode: 'lb_cluster'                     # Mode can be standalone or lb_cluster (load balanced cluster) 
+      mode: 'lb_cluster'                     # Mode can be standalone or lb_cluster (load balanced cluster)
       use_pfring: 'False'                    # If pf_ring is installed set this to True. Must use "pf_ring" lb_method
       use_afpacket: 'True'                   # If you use AF_PACKET set this to True. Must use "custom" lb_method and use_BroPKG set to True
       lb_method: 'custom'                    # Load balancer type ("pf_ring" or "custom" are supported)
@@ -61,9 +65,10 @@ bro:
         use_sendmail: 'False'                # Use sendmail(needs sendmail/postfix to be installed)
         relayhost: 'mail.domain.tld'         # Send email to a relay host
       interfaces:
-        ip_binary_path: '/sbin/ip'           # path to ip binary for managing 
+        ip_binary_path: '/sbin/ip'           # path to ip binary for managing
         management: 'ens192'                 # Management interface name
-        capture: 
+        capture:
+          enable: 'True'
           device_names: 'ens224'             # Capture interface name (currently only supports 1 interface)
           enable_tx: '0'                     # Enable tx send on this interface (default is 0)
           min_num_slots: '4096'              # Min Slots check support on card using ethtool -g eth1

--- a/test/integration/default/README.md
+++ b/test/integration/default/README.md
@@ -1,0 +1,50 @@
+# InSpec Profile: `default`
+
+This shows the implementation of the `default` InSpec [profile](https://github.com/inspec/inspec/blob/master/docs/profiles.md).
+
+## Verify a profile
+
+InSpec ships with built-in features to verify a profile structure.
+
+```bash
+$ inspec check default
+Summary
+-------
+Location: default
+Profile: profile
+Controls: 4
+Timestamp: 2019-06-24T23:09:01+00:00
+Valid: true
+
+Errors
+------
+
+Warnings
+--------
+```
+
+## Execute a profile
+
+To run all **supported** controls on a local machine use `inspec exec /path/to/profile`.
+
+```bash
+$ inspec exec default
+..
+
+Finished in 0.0025 seconds (files took 0.12449 seconds to load)
+8 examples, 0 failures
+```
+
+## Execute a specific control from a profile
+
+To run one control from the profile use `inspec exec /path/to/profile --controls name`.
+
+```bash
+$ inspec exec default --controls package
+.
+
+Finished in 0.0025 seconds (files took 0.12449 seconds to load)
+1 examples, 0 failures
+```
+
+See an [example control here](https://github.com/inspec/inspec/blob/master/examples/profile/controls/example.rb).

--- a/test/integration/default/controls/config_spec.rb
+++ b/test/integration/default/controls/config_spec.rb
@@ -1,0 +1,17 @@
+#override by OS
+if os.family == 'debian'
+  file_name = '/etc/bro/node.cfg'
+elsif os.family == 'redhat'
+  file_name = '/opt/bro/etc/node.cfg'
+end
+
+control 'bro configuration' do
+  title 'should match desired lines'
+
+  describe file(file_name) do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'bro' }
+    its('mode') { should cmp '0664' }
+  end
+end

--- a/test/integration/default/controls/ldconfig_spec.rb
+++ b/test/integration/default/controls/ldconfig_spec.rb
@@ -1,0 +1,14 @@
+if os.family == 'redhat'
+  control 'bro library configuration' do
+    title 'should match desired lines'
+
+    describe file('/etc/ld.so.conf.d/bro-x86_64.conf') do
+      it { should be_file }
+      it { should be_owned_by 'root' }
+      it { should be_grouped_into 'root' }
+      its('mode') { should cmp '0644' }
+      its('content') { should include '/opt/bro/lib' }
+      its('content') { should include '/opt/bro/lib64' }
+    end
+  end
+end

--- a/test/integration/default/controls/packages_spec.rb
+++ b/test/integration/default/controls/packages_spec.rb
@@ -1,0 +1,13 @@
+# Overide by OS
+package_name = 'bro'
+if os[:name] == 'centos' and os[:release].start_with?('6')
+  package_name = 'bro'
+end
+
+control 'bro package' do
+  title 'should be installed'
+
+  describe package(package_name) do
+    it { should be_installed }
+  end
+end

--- a/test/integration/default/controls/services_spec.rb
+++ b/test/integration/default/controls/services_spec.rb
@@ -1,0 +1,15 @@
+# Overide by OS
+service_name = 'bro'
+if os[:name] == 'centos' and os[:release].start_with?('6')
+  service_name = 'bro'
+end
+
+control 'bro service' do
+  impact 0.5
+  title 'should be running and enabled'
+
+  describe service(service_name) do
+    it { should be_enabled }
+    it { should be_running }
+  end
+end

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,0 +1,15 @@
+name: default
+title: bro formula
+maintainer: SaltStack Formulas
+license: Apache-2.0
+summary: Verify that the bro formula is setup and configured correctly
+version: 1.0.0
+supports:
+  - platform-name: debian
+  - platform-name: ubuntu
+  - platform-name: centos
+  - platform-name: fedora
+  - platform-name: opensuse
+  - platform-name: suse
+  - platform-name: freebsd
+  - platform-name: amazon

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -3,7 +3,7 @@ bro:
   lookup:
     package:
     {% if grains['os_family'] == 'RedHat' %}
-      install_type: 'local'                         # Install type can be package or local (support for tarball not implemented) 
+      install_type: 'local'                         # Install type can be package or local (support for tarball not implemented)
       local_package:                                # Can be multiple packages like bro, broctl, broccoli etc.
         - pack_id: 'bro-full'
           package: 'Bro-2.6-195-Linux-x86_64'       # Custom package to be deployed
@@ -14,7 +14,7 @@ bro:
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/repodata/repomd.xml.key'
       skip_verify: '0'
     {% elif grains['os_family'] == 'Debian' %}
-      install_type: 'package'                       # Install type can be package (support for tarball or local not implemented) 
+      install_type: 'package'                       # Install type can be package (support for tarball or local not implemented)
       use_repo: 'False'                             # Debian 9 does not require an external repo
       repo_baseurl: 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:bro/Debian_8.0/Release.key'
@@ -28,7 +28,7 @@ bro:
       python_pip_pkg: 'python3-pip'         # Can be pip or pip3 but only gets installed if use_BroPKG == True
     {% endif %}
       python_pip_cmd: 'pip3'                 # Otherwise, the pip install is skipped and bro-pkg is not configured
-      addon_plugins:                         # List of plugins to install if bro-pkg is enabled 
+      addon_plugins:                         # List of plugins to install if bro-pkg is enabled
         - plugin: 'bro-af_packet-plugin'     # af_packet is required when use_afpacket == True
       MailTo: 'root@localhost'               # Recipient address for all emails sent out by Bro and BroControl
       SendMail: '/sbin/sendmail'             # Path to sendmail binary
@@ -52,11 +52,13 @@ bro:
       CfgDir: '/etc/bro'                     # Default config directory location for Debian
       ShareDir: '/usr/share/bro'             # Location of shared resources (site local)
     {% endif %}
-      mode: 'standalone'                     # Mode can be standalone or lb_cluster (load balanced cluster) 
+      mode: 'standalone'                     # Mode can be standalone or lb_cluster (load balanced cluster)
       use_pfring: 'False'                    # If pf_ring is installed set this to True. Must use "pf_ring" lb_method
       use_afpacket: 'True'                   # If you use AF_PACKET set this to True. Must use "custom" lb_method and use_BroPKG set to True
       lb_method: 'custom'                    # Load balancer type ("pf_ring" or "custom" are supported)
       lb_procs: '2'                          # Number of processors to run BRO workers with
+      logging:
+        use_rsyslog: 'False'                 # Enable rsyslog usage
       bpf:
         use_BPFconf: 'True'                  # Use Berkeley Packet Filter(BPF) on capture interfaces
         bpf_rules: []                        # Add custom BPF rules
@@ -65,7 +67,7 @@ bro:
         use_sendmail: 'False'                # Use sendmail(needs sendmail/postfix to be installed)
         relayhost: 'mail.domain.tld'         # Send email to a relay host
       interfaces:
-        ip_binary_path: '/sbin/ip'           # path to ip binary for managing 
+        ip_binary_path: '/sbin/ip'           # path to ip binary for managing
         management: 'eth0'                 # Management interface name
         capture:
           enable: 'False'

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -1,0 +1,74 @@
+# BRO docs https://www.bro.org/documentation/index.html
+bro:
+  lookup:
+    package:
+    {% if grains['os_family'] == 'RedHat' %}
+      install_type: 'local'                         # Install type can be package or local (support for tarball not implemented) 
+      local_package:                                # Can be multiple packages like bro, broctl, broccoli etc.
+        - pack_id: 'bro-full'
+          package: 'Bro-2.6-195-Linux-x86_64'       # Custom package to be deployed
+          name: 'bro'                               # Name of installed package
+          type: 'rpm'                               # Type should be deb or rpm based on platform
+      use_repo: 'False'                             # Bro can be installed from epel or a local rpm not just bro repos
+      repo_baseurl: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/'
+      repo_gpgkey: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/repodata/repomd.xml.key'
+      skip_verify: '0'
+    {% elif grains['os_family'] == 'Debian' %}
+      install_type: 'package'                       # Install type can be package (support for tarball or local not implemented) 
+      use_repo: 'False'                             # Debian 9 does not require an external repo
+      repo_baseurl: 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/'
+      repo_gpgkey: 'http://download.opensuse.org/repositories/network:bro/Debian_8.0/Release.key'
+      skip_verify: '0'
+    {% endif %}
+    bro:
+      use_BroPKG: 'True'                     # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
+    {% if grains['os_family'] == 'RedHat' %}
+      python_pip_pkg: 'python36-pip'         # Can be pip or pip3 but only gets installed if use_BroPKG == True
+    {% elif grains['os_family'] == 'Debian' %}
+      python_pip_pkg: 'python3-pip'         # Can be pip or pip3 but only gets installed if use_BroPKG == True
+    {% endif %}
+      python_pip_cmd: 'pip3'                 # Otherwise, the pip install is skipped and bro-pkg is not configured
+      addon_plugins:                         # List of plugins to install if bro-pkg is enabled 
+        - plugin: 'bro-af_packet-plugin'     # af_packet is required when use_afpacket == True
+      MailTo: 'root@localhost'               # Recipient address for all emails sent out by Bro and BroControl
+      SendMail: '/sbin/sendmail'             # Path to sendmail binary
+      MailConnectionSummary: '1'             # Send mail connection summaries
+      MinDiskSpace: '5'                      # Threshold (in percentage of disk space) for HDD where SpoolDir lives
+      MailHostUpDown: '1'                    # Send mail when "broctl cron" notices a host in the cluster has changed
+      LogRotationInterval: '3600'            # Log rotation interval in seconds for current logs
+      LogExpireInterval: '0'                 # Files older than this will be deleted by "broctl cron" 0 is never
+      StatsLogEnable: '1'                    # Enable BroControl to write statistics to the stats.log file
+      StatsLogExpireInterval: '0'            # Number of days that entries in the stats.log file are kept
+      StatusCmdShowAll: '0'                  # Show all output of the broctl status command
+      CrashExpireInterval: '0'               # Number of days that crash directories are kept
+      SitePolicyScripts: 'local.bro'         # Site-specific policy script to load
+    {% if grains['os_family'] == 'RedHat' %}
+      base_dir: '/opt/bro'                   # /opt/bro is default for yum package install
+    {% elif grains['os_family'] == 'Debian' %}
+      base_dir: '/usr/bin'                   # /usr/bin is default for deb package install
+      BinDir: '/usr/bin'                     # Default location of executables on Debian
+      LogDir: '/var/log/bro'                 # Default location of log directory on Debian
+      SpoolDir: '/var/spool/bro'             # Default location of spool directory on Debian
+      CfgDir: '/etc/bro'                     # Default config directory location for Debian
+      ShareDir: '/usr/share/bro'             # Location of shared resources (site local)
+    {% endif %}
+      mode: 'standalone'                     # Mode can be standalone or lb_cluster (load balanced cluster) 
+      use_pfring: 'False'                    # If pf_ring is installed set this to True. Must use "pf_ring" lb_method
+      use_afpacket: 'True'                   # If you use AF_PACKET set this to True. Must use "custom" lb_method and use_BroPKG set to True
+      lb_method: 'custom'                    # Load balancer type ("pf_ring" or "custom" are supported)
+      lb_procs: '2'                          # Number of processors to run BRO workers with
+      bpf:
+        use_BPFconf: 'True'                  # Use Berkeley Packet Filter(BPF) on capture interfaces
+        bpf_rules: []                        # Add custom BPF rules
+      optional:
+        use_LibgeoIP: 'False'                # Use LibgeoIP(less useful if sending logs upstream)
+        use_sendmail: 'False'                # Use sendmail(needs sendmail/postfix to be installed)
+        relayhost: 'mail.domain.tld'         # Send email to a relay host
+      interfaces:
+        ip_binary_path: '/sbin/ip'           # path to ip binary for managing 
+        management: 'eth0'                 # Management interface name
+        capture:
+          enable: 'False'
+          device_names: 'eth0'             # Capture interface name (currently only supports 1 interface)
+          enable_tx: '0'                     # Enable tx send on this interface (default is 0)
+          min_num_slots: '4096'              # Min Slots check support on card using ethtool -g eth1

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -3,7 +3,7 @@ bro:
   lookup:
     package:
     {% if grains['os_family'] == 'RedHat' %}
-      install_type: 'local'                         # Install type can be package or local (support for tarball not implemented)
+      install_type: 'local'                         # Install type can be package or local (support for tarball not implemented) 
       local_package:                                # Can be multiple packages like bro, broctl, broccoli etc.
         - pack_id: 'bro-full'
           package: 'Bro-2.6-195-Linux-x86_64'       # Custom package to be deployed
@@ -14,21 +14,25 @@ bro:
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/repodata/repomd.xml.key'
       skip_verify: '0'
     {% elif grains['os_family'] == 'Debian' %}
-      install_type: 'package'                       # Install type can be package (support for tarball or local not implemented)
+      install_type: 'package'                       # Install type can be package (support for tarball or local not implemented) 
       use_repo: 'False'                             # Debian 9 does not require an external repo
       repo_baseurl: 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:bro/Debian_8.0/Release.key'
       skip_verify: '0'
     {% endif %}
     bro:
+    {% if grains['osfinger'] == 'Ubuntu-16.04' %} #Ubuntu 16 throws an error for now disabling this until fixed
+      use_BroPKG: 'False'                    # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
+    {% else %}
       use_BroPKG: 'True'                     # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
+    {% endif %}
     {% if grains['os_family'] == 'RedHat' %}
       python_pip_pkg: 'python36-pip'         # Can be pip or pip3 but only gets installed if use_BroPKG == True
     {% elif grains['os_family'] == 'Debian' %}
       python_pip_pkg: 'python3-pip'         # Can be pip or pip3 but only gets installed if use_BroPKG == True
     {% endif %}
       python_pip_cmd: 'pip3'                 # Otherwise, the pip install is skipped and bro-pkg is not configured
-      addon_plugins:                         # List of plugins to install if bro-pkg is enabled
+      addon_plugins:                         # List of plugins to install if bro-pkg is enabled 
         - plugin: 'bro-af_packet-plugin'     # af_packet is required when use_afpacket == True
       MailTo: 'root@localhost'               # Recipient address for all emails sent out by Bro and BroControl
       SendMail: '/sbin/sendmail'             # Path to sendmail binary
@@ -52,7 +56,7 @@ bro:
       CfgDir: '/etc/bro'                     # Default config directory location for Debian
       ShareDir: '/usr/share/bro'             # Location of shared resources (site local)
     {% endif %}
-      mode: 'standalone'                     # Mode can be standalone or lb_cluster (load balanced cluster)
+      mode: 'standalone'                     # Mode can be standalone or lb_cluster (load balanced cluster) 
       use_pfring: 'False'                    # If pf_ring is installed set this to True. Must use "pf_ring" lb_method
       use_afpacket: 'True'                   # If you use AF_PACKET set this to True. Must use "custom" lb_method and use_BroPKG set to True
       lb_method: 'custom'                    # Load balancer type ("pf_ring" or "custom" are supported)
@@ -60,14 +64,18 @@ bro:
       logging:
         use_rsyslog: 'False'                 # Enable rsyslog usage
       bpf:
+      {% if grains['osfinger'] == 'Ubuntu-16.04' %} #Ubuntu 16 throws an error for now disabling this until fixed
+        use_BPFconf: 'False'                 # Use Berkeley Packet Filter(BPF) on capture interfaces
+      {% else %}
         use_BPFconf: 'True'                  # Use Berkeley Packet Filter(BPF) on capture interfaces
+      {% endif %}
         bpf_rules: []                        # Add custom BPF rules
       optional:
         use_LibgeoIP: 'False'                # Use LibgeoIP(less useful if sending logs upstream)
         use_sendmail: 'False'                # Use sendmail(needs sendmail/postfix to be installed)
         relayhost: 'mail.domain.tld'         # Send email to a relay host
       interfaces:
-        ip_binary_path: '/sbin/ip'           # path to ip binary for managing
+        ip_binary_path: '/sbin/ip'           # path to ip binary for managing 
         management: 'eth0'                 # Management interface name
         capture:
           enable: 'False'

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -31,7 +31,7 @@ bro:
     {% if grains['osfinger'] == 'Ubuntu-16.04' %} #Ubuntu 16 throws an error for now disabling this until fixed
       use_BroPKG: 'False'                    # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
     {% else %}
-      use_BroPKG: 'False'                    # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
+      use_BroPKG: 'True'                    # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
     {% endif %}
       addon_plugins:                         # List of plugins to install if bro-pkg is enabled 
         - plugin: 'bro-af_packet-plugin'     # af_packet is required when use_afpacket == True

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -31,7 +31,7 @@ bro:
     {% if grains['osfinger'] == 'Ubuntu-16.04' %} #Ubuntu 16 throws an error for now disabling this until fixed
       use_BroPKG: 'False'                    # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
     {% else %}
-      use_BroPKG: 'True'                    # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
+      use_BroPKG: 'False'                    # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
     {% endif %}
       addon_plugins:                         # List of plugins to install if bro-pkg is enabled 
         - plugin: 'bro-af_packet-plugin'     # af_packet is required when use_afpacket == True

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -22,17 +22,17 @@ bro:
       skip_verify: '0'
     {% endif %}
     bro:
-    {% if grains['osfinger'] == 'Ubuntu-16.04' %} #Ubuntu 16 throws an error for now disabling this until fixed
-      use_BroPKG: 'False'                    # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
-    {% else %}
-      use_BroPKG: 'True'                     # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
-    {% endif %}
     {% if grains['os_family'] == 'RedHat' %}
       python_pip_pkg: 'python36-pip'         # Can be pip or pip3 but only gets installed if use_BroPKG == True
     {% elif grains['os_family'] == 'Debian' %}
       python_pip_pkg: 'python3-pip'         # Can be pip or pip3 but only gets installed if use_BroPKG == True
     {% endif %}
       python_pip_cmd: 'pip3'                 # Otherwise, the pip install is skipped and bro-pkg is not configured
+    {% if grains['osfinger'] == 'Ubuntu-16.04' %} #Ubuntu 16 throws an error for now disabling this until fixed
+      use_BroPKG: 'False'                    # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
+    {% else %}
+      use_BroPKG: 'False'                    # Use bro-pkg to manage plugins (requird for plugins such as af_packet etc)
+    {% endif %}
       addon_plugins:                         # List of plugins to install if bro-pkg is enabled 
         - plugin: 'bro-af_packet-plugin'     # af_packet is required when use_afpacket == True
       MailTo: 'root@localhost'               # Recipient address for all emails sent out by Bro and BroControl

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -9,12 +9,17 @@ bro:
           package: 'Bro-2.6-195-Linux-x86_64'       # Custom package to be deployed
           name: 'bro'                               # Name of installed package
           type: 'rpm'                               # Type should be deb or rpm based on platform
+          files_path: '/tmp/kitchen/srv/salt/bro/files'  # Local file path for package storage
+          source_url: 'https://git.io/fj7g3'        # Short link to alias454 gists where test package lives
+          hash: 'a3ab22252d25a1b8cc50ca0e681cacee9bbd93472dd51ae741eafa23016d21cf'
+      use_remote_pkg: 'True'                        # Get local_package file from a remote source
       use_repo: 'False'                             # Bro can be installed from epel or a local rpm not just bro repos
       repo_baseurl: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/repodata/repomd.xml.key'
       skip_verify: '0'
     {% elif grains['os_family'] == 'Debian' %}
       install_type: 'package'                       # Install type can be package (support for tarball or local not implemented) 
+      use_remote_pkg: 'False'                       # Get local_package file from a remote source
       use_repo: 'False'                             # Debian 9 does not require an external repo
       repo_baseurl: 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:bro/Debian_8.0/Release.key'

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 # BRO docs https://www.bro.org/documentation/index.html
 bro:
   lookup:

--- a/test/salt/pillar/default.sls
+++ b/test/salt/pillar/default.sls
@@ -9,17 +9,13 @@ bro:
           package: 'Bro-2.6-195-Linux-x86_64'       # Custom package to be deployed
           name: 'bro'                               # Name of installed package
           type: 'rpm'                               # Type should be deb or rpm based on platform
-          files_path: '/tmp/kitchen/srv/salt/bro/files'  # Local file path for package storage
-          source_url: 'https://git.io/fj7g3'        # Short link to alias454 gists where test package lives
-          hash: 'a3ab22252d25a1b8cc50ca0e681cacee9bbd93472dd51ae741eafa23016d21cf'
-      use_remote_pkg: 'True'                        # Get local_package file from a remote source
+          source: 'https://gist.github.com/alias454/2fab378323e712b4c80ad6fb667696b2/raw' # Link to alias454 gist where test package lives (no trailing /)
       use_repo: 'False'                             # Bro can be installed from epel or a local rpm not just bro repos
       repo_baseurl: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:/bro/CentOS_7/repodata/repomd.xml.key'
       skip_verify: '0'
     {% elif grains['os_family'] == 'Debian' %}
       install_type: 'package'                       # Install type can be package (support for tarball or local not implemented) 
-      use_remote_pkg: 'False'                       # Get local_package file from a remote source
       use_repo: 'False'                             # Debian 9 does not require an external repo
       repo_baseurl: 'deb http://download.opensuse.org/repositories/network:/bro/Debian_8.0/'
       repo_gpgkey: 'http://download.opensuse.org/repositories/network:bro/Debian_8.0/Release.key'


### PR DESCRIPTION
Rework states to support automated testing with kitchen-salt and docker:
- add option to enable/disable capture interface
- add library paths when rpm install fails to create file
- install cron package when missing
- add FORMULA file

Formula has been tested with salt >= 2018.3 on:
- Debian 9
- Ubuntu 18.04
- CentOS 7

Other changes:
- add remote logging configuration support for rsyslog 